### PR TITLE
removing erroneous comma

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "dev": "NODE_ENV=development node --harmony bin/webpack-dev-server",
     "mocha": "mocha --recursive --compilers js:babel-core/register",
     "mocha:watch": "npm run mocha -- --watch",
-    "coverage": "istanbul cover node_modules/mocha/bin/_mocha -- --recursive --compilers js:babel/register --colors --reporter dot test/",
+    "coverage": "istanbul cover node_modules/mocha/bin/_mocha -- --recursive --compilers js:babel/register --colors --reporter dot test/"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The trailing comma was making the install fail:

```
$ npm install
npm ERR! install Couldn't read dependencies
npm ERR! Darwin 14.5.0
npm ERR! argv "node" "/usr/local/bin/npm" "install"
npm ERR! node v0.12.7
npm ERR! npm  v2.12.1
npm ERR! file /Users/mcenac/projects/tmp/react-redux-jwt-auth-example/package.json
npm ERR! code EJSONPARSE

npm ERR! Failed to parse json
npm ERR! Trailing comma in object at 13:3
npm ERR!   },
npm ERR!   ^
npm ERR! File: /Users/mcenac/projects/tmp/react-redux-jwt-auth-example/package.json
npm ERR! Failed to parse package.json data.
npm ERR! package.json must be actual JSON, not just JavaScript.
npm ERR!
npm ERR! This is not a bug in npm.
npm ERR! Tell the package author to fix their package.json file. JSON.parse

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/mcenac/projects/tmp/react-redux-jwt-auth-example/npm-debug.log
```