### PR TITLE
Using .env on windows for set up NODE_ENV=development with npm start

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+NODE_ENV=development

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "compile": "NODE_ENV=production webpack",
-    "start": "npm run dev",
+    "start": "node ./server.js",
     "dev": "NODE_ENV=development node --harmony bin/webpack-dev-server",
     "mocha": "mocha --recursive --compilers js:babel-core/register",
     "mocha:watch": "npm run mocha -- --watch",

--- a/server.js
+++ b/server.js
@@ -1,4 +1,5 @@
 'use strict';
+require('dotenv').load();
 
 const webpack = require('webpack');
 const webpackDevMiddleware = require('webpack-dev-middleware');


### PR DESCRIPTION
It is difficult for beginners to manage NODE_ENV environment variable on windows. I have found it much easier to use 'npm start' instead of manage NODE_ENV from the command line. The change worked well on windows, it should be fine on linux too.